### PR TITLE
chore(infra): configure o devcontainer para Joomla

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,3 +5,11 @@ FROM joomla:${VARIANT}
 RUN curl -sSL https://getcomposer.org/installer | php \
     && chmod +x composer.phar \
     && mv composer.phar /usr/local/bin/composer
+
+# Install Xdebug
+RUN yes | pecl install xdebug \
+    && echo "zend_extension = $(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.client_port = 9000" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && rm -rf /tmp/pear

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+ARG VARIANT=5.2-php8.2-apache
+FROM joomla:${VARIANT}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,7 @@
 ARG VARIANT=5.2-php8.2-apache
 FROM joomla:${VARIANT}
+
+# Install composer
+RUN curl -sSL https://getcomposer.org/installer | php \
+    && chmod +x composer.phar \
+    && mv composer.phar /usr/local/bin/composer

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,44 +1,44 @@
 name: joomla-mariadb-devcontainer
 
 services:
-    app:
-        build:
-            context: .
-            dockerfile: Dockerfile
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
 
-        volumes:
-            - ../..:/workspaces:cached
+    volumes:
+      - ../..:/workspaces:cached
 
-        environment:
-            JOOMLA_DB_HOST: db
-            JOOMLA_DB_USER: joomla
-            JOOMLA_DB_PASSWORD: joomla
-            JOOMLA_DB_NAME: joomladb
-            JOOMLA_SITE_NAME: "Demo Site"
-            JOOMLA_ADMIN_USER: Administrator
-            JOOMLA_ADMIN_USERNAME: joomladmin
-            JOOMLA_ADMIN_PASSWORD: MyStr0ngP4ssw0rd
-            JOOMLA_ADMIN_EMAIL: demo@joomla.org
+    environment:
+      JOOMLA_DB_HOST: db
+      JOOMLA_DB_USER: joomla
+      JOOMLA_DB_PASSWORD: joomla
+      JOOMLA_DB_NAME: joomladb
+      JOOMLA_SITE_NAME: "Demo Site"
+      JOOMLA_ADMIN_USER: Administrator
+      JOOMLA_ADMIN_USERNAME: joomladmin
+      JOOMLA_ADMIN_PASSWORD: MyStr0ngP4ssw0rd
+      JOOMLA_ADMIN_EMAIL: demo@joomla.org
 
-        # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-        network_mode: service:db
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
 
-        # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
-        # (Adding the "ports" property to this file will not forward from a Codespace.)
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
 
-    db:
-        image: mariadb:10.4
-        restart: unless-stopped
-        volumes:
-            - mariadb-data:/var/lib/mysql
-        environment:
-            MARIADB_ROOT_PASSWORD: joomla
-            MARIADB_DATABASE: joomladb
-            MARIADB_USER: joomla
-            MARIADB_PASSWORD: joomla
+  db:
+    image: mariadb:10.4
+    restart: unless-stopped
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      MARIADB_ROOT_PASSWORD: joomla
+      MARIADB_DATABASE: joomladb
+      MARIADB_USER: joomla
+      MARIADB_PASSWORD: joomla
 
-        # Add "forwardPorts": ["3306"] to **devcontainer.json** to forward MariaDB locally.
-        # (Adding the "ports" property to this file will not forward from a Codespace.)
+    # Add "forwardPorts": ["3306"] to **devcontainer.json** to forward MariaDB locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
 
 volumes:
-    mariadb-data:
+  mariadb-data:

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,0 +1,44 @@
+name: joomla-mariadb-devcontainer
+
+services:
+    app:
+        build:
+            context: .
+            dockerfile: Dockerfile
+
+        volumes:
+            - ../..:/workspaces:cached
+
+        environment:
+            JOOMLA_DB_HOST: db
+            JOOMLA_DB_USER: joomla
+            JOOMLA_DB_PASSWORD: joomla
+            JOOMLA_DB_NAME: joomladb
+            JOOMLA_SITE_NAME: "Demo Site"
+            JOOMLA_ADMIN_USER: Administrator
+            JOOMLA_ADMIN_USERNAME: joomladmin
+            JOOMLA_ADMIN_PASSWORD: MyStr0ngP4ssw0rd
+            JOOMLA_ADMIN_EMAIL: demo@joomla.org
+
+        # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+        network_mode: service:db
+
+        # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+        # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+    db:
+        image: mariadb:10.4
+        restart: unless-stopped
+        volumes:
+            - mariadb-data:/var/lib/mysql
+        environment:
+            MARIADB_ROOT_PASSWORD: joomla
+            MARIADB_DATABASE: joomladb
+            MARIADB_USER: joomla
+            MARIADB_PASSWORD: joomla
+
+        # Add "forwardPorts": ["3306"] to **devcontainer.json** to forward MariaDB locally.
+        # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+    mariadb-data:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
       "userUid": "1000",
       "userGid": "1000",
       "upgradePackages": "true"
-    }
+    },
+    "./local-features/user-config": "latest"
   },
 
   "forwardPorts": [80],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+  "name": "Joomla & MariaDB",
+  "dockerComposeFile": "compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": "true",
+      "username": "vscode",
+      "userUid": "1000",
+      "userGid": "1000",
+      "upgradePackages": "true"
+    }
+  },
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html"
+
+  // Configure tool-specific properties.
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+        "php.validate.executablePath": "/usr/local/bin/php"
+      },
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "bmewburn.vscode-intelephense-client",
+        "EditorConfig.EditorConfig",
+        "xdebug.php-debug"
+      ]
+    }
+  },
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
     "./local-features/user-config": "latest"
   },
 
-  "forwardPorts": [80],
+  "forwardPorts": [8080],
 
   // Use 'postCreateCommand' to run commands after the container is created.
   // "postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,8 @@
     }
   },
 
+  "forwardPorts": [80],
+
   // Use 'postCreateCommand' to run commands after the container is created.
   // "postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html"
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,6 +33,7 @@
       "extensions": [
         "bmewburn.vscode-intelephense-client",
         "EditorConfig.EditorConfig",
+        "esbenp.prettier-vscode",
         "xdebug.php-debug"
       ]
     }

--- a/.devcontainer/local-features/apache-config/devcontainer-feature.json
+++ b/.devcontainer/local-features/apache-config/devcontainer-feature.json
@@ -1,0 +1,4 @@
+{
+  "id": "apache-config",
+  "name": "Apache configuration changes"
+}

--- a/.devcontainer/local-features/apache-config/install.sh
+++ b/.devcontainer/local-features/apache-config/install.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+sed -i -e "s/Listen 80/Listen 80\\nListen 8080/g" /etc/apache2/ports.conf
+
+echo "Done!"

--- a/.devcontainer/local-features/user-config/devcontainer-feature.json
+++ b/.devcontainer/local-features/user-config/devcontainer-feature.json
@@ -1,0 +1,5 @@
+{
+  "id": "user-config",
+  "name": "User configuration",
+  "installsAfter": ["ghcr.io/devcontainers/features/common-utils"]
+}

--- a/.devcontainer/local-features/user-config/install.sh
+++ b/.devcontainer/local-features/user-config/install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+USERNAME="vscode"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+usermod -aG www-data ${USERNAME}
+
+echo "Done!"

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ insert_final_newline = true
 indent_size = 1
 trim_trailing_whitespace = false
 
-[*.{css,scss,js,json, yml}]
+[*.{css,scss,js,json,yml,yaml}]
 indent_size = 2
 
 [Dockerfile]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# Portal Padrão em Joomla! CMS para o Design System do Governo Brasileiro
+# govbr-ds
 
-> Portal implementado em Joomla! CMS conforme o Padrão Digital de Governo instituído pela [Portaria Nº 540, de 8 de setembro de 2020 - Secretaria de Governo/Presidência da República](https://www.in.gov.br/en/web/dou/-/portaria-n-540-de-8-de-setembro-de-2020-276907456).
+> Template para Joomla! CMS para o Design System do Governo Brasileiro.
 
-Este portal aplica as especificações dispostas no [Design System Padrão de Governo](https://www.gov.br/ds/).
+Template desenvolvido para Joomla! CMS conforme o Padrão Digital de Governo instituído pela [Portaria Nº 540, de 8 de setembro de 2020 - Secretaria de Governo/Presidência da República](https://www.in.gov.br/en/web/dou/-/portaria-n-540-de-8-de-setembro-de-2020-276907456).
+
+> [!IMPORTANT]
+> Este template aplica as especificações dispostas no [Design System Padrão de Governo](https://www.gov.br/ds/).
 
 ## Requisitos
 
@@ -46,7 +49,7 @@ Copyright (c) 2024 Rene Bentes Pinto
 
 Este projeto está sob a licença **GNU GPL v2.0**. Veja o arquivo [LICENSE](LICENSE) para mais detalhes.
 
-[repo]: http://github.com/renebentes/repository
+[repo]: http://github.com/8becnst/joomla-govbr-ds
 [issues]: ../../issues
 [pulls]: ../../pulls
 [changelog]: ../../commits


### PR DESCRIPTION
Este projeto utiliza o Joomla, um CMS (Content Management System) de código aberto, para criar e
gerencia sites. Para facilitar o desenvolvimento e a colaboração, configuramos um ambiente de
desenvolvimento com o Devcontainer, que permite que os desenvolvedores trabalhem em um ambiente
consistente e reproduzível, independentemente de suas configurações locais.

Utilizamos como base a imagem oficial do Joomla, que já vem com o PHP e o Apache pré-instalados. O
Devcontainer é configurado para expor a porta 8080, permitindo que os desenvolvedores acessem o Joomla
pelo navegador. Além disso, o ambiente inclui algumas extensões para facilitar o desenvolvimento,
como PHP Intelephense, PHP Debug, EditorConfig e Prettier.